### PR TITLE
Preview and run file paths fixed.

### DIFF
--- a/app.py
+++ b/app.py
@@ -97,6 +97,7 @@ app.layout = html.Div(
         Output("run-page-alert", "is_open"),
         Output("run-page-alert", "children"),
         Output("progress-message-run-page-markdown", "children"),
+        Output("progress-message-run-page-for-analysis", "children"),
     ],
     inputs=[
         Input("submit-analysis", "n_clicks"),
@@ -112,11 +113,6 @@ app.layout = html.Div(
         ),
         (
             Output("progress-bar-run-page", "style"),
-            {"visibility": "visible"},
-            {"visibility": "hidden"},
-        ),
-        (
-            Output("progress-message-run-page-for-analysis", "style"),
             {"visibility": "visible"},
             {"visibility": "hidden"},
         ),
@@ -169,6 +165,7 @@ def background_callback(set_progress, n_clicks, store):
             True,
             "An error has occurred. Please see the log file for more information.",
             f"```{error_message}```",
+            None,
         )
 
 

--- a/app/components/preview_layout.py
+++ b/app/components/preview_layout.py
@@ -6,7 +6,7 @@
 
 import dash_bootstrap_components as dbc
 from dash import dcc, html
-from app.utils.styling import layout
+from app.utils.styling import layout, clear_alert_style
 
 # Assuming we have a fixed height for the headers and buttons in CSS
 fixed_header_class = "fixed-header"
@@ -55,8 +55,25 @@ preview_layout = dbc.ModalBody(
                                         ),
                                         dbc.Row(
                                             [
-                                                html.P("Raw image:"),
-                                                dcc.Markdown(id="input-path-output"),
+                                                dbc.Row(
+                                                    [
+                                                        html.P("Path to raw image:"),
+                                                    ]
+                                                ),
+                                                dbc.Row(
+                                                    [
+                                                        dbc.Alert(
+                                                            id="input-path-output-alert",
+                                                            style=clear_alert_style,
+                                                            is_open=True,
+                                                            children=[
+                                                                dcc.Markdown(
+                                                                    id="input-path-output"
+                                                                ),
+                                                            ],
+                                                        ),
+                                                    ]
+                                                ),
                                             ]
                                         ),
                                         dbc.Row(
@@ -137,9 +154,36 @@ preview_layout = dbc.ModalBody(
                                         ),
                                         dbc.Row(
                                             [
-                                                html.P("Command:"),
-                                                dcc.Markdown(
-                                                    id="analysis-preview-message"
+                                                dbc.Row(
+                                                    [
+                                                        html.P(
+                                                            "Path to diagnostic image:"
+                                                        ),
+                                                    ]
+                                                ),
+                                                dbc.Row(
+                                                    [
+                                                        dbc.Alert(
+                                                            id="analysis-preview-message-alert",
+                                                            style=clear_alert_style,
+                                                            is_open=True,
+                                                            children=[
+                                                                dcc.Markdown(
+                                                                    id="analysis-preview-message"
+                                                                ),
+                                                            ],
+                                                        ),
+                                                        dbc.Alert(
+                                                            id="analysis-preview-dx-alert-message",
+                                                            style=clear_alert_style,
+                                                            is_open=False,
+                                                            children=[
+                                                                dcc.Markdown(
+                                                                    id="analysis-preview-dx-message"
+                                                                ),
+                                                            ],
+                                                        ),
+                                                    ],
                                                 ),
                                             ]
                                         ),

--- a/app/components/run_layout.py
+++ b/app/components/run_layout.py
@@ -8,7 +8,7 @@ import dash_bootstrap_components as dbc
 from dash import dcc, html
 
 # importing utils
-from app.utils.styling import layout
+from app.utils.styling import layout, clear_alert_style
 
 ########################################################################
 ####                                                                ####
@@ -142,19 +142,43 @@ run_layout = dbc.ModalBody(
                                         ),
                                         dbc.Row(
                                             [
-                                                html.H6(
-                                                    # File
-                                                    "File:",
-                                                    className="card-subtitle",
-                                                    style={"margin-top": "7px"},
+                                                dbc.Row(
+                                                    [
+                                                        html.H6(
+                                                            # File
+                                                            "File:",
+                                                            className="card-subtitle",
+                                                            style={"margin-top": "7px"},
+                                                        )
+                                                    ]
                                                 ),
-                                                dcc.Markdown(
-                                                    # Progress message for progress file paths
-                                                    id="progress-message-run-page-for-analysis"
-                                                ),
-                                                dcc.Markdown(
-                                                    # Message for analysis
-                                                    id="analysis-postview-message"
+                                                dbc.Row(
+                                                    [
+                                                        dbc.Alert(
+                                                            # Alert for running file paths
+                                                            id="run-page-file-paths-alert",
+                                                            style=clear_alert_style,
+                                                            is_open=True,
+                                                            children=[
+                                                                dcc.Markdown(
+                                                                    # Progress message for progress file paths
+                                                                    id="progress-message-run-page-for-analysis"
+                                                                ),
+                                                            ],
+                                                        ),
+                                                        dbc.Alert(
+                                                            # Alert for file paths when updating dx image
+                                                            id="run-page-file-paths-alert-update",
+                                                            style=clear_alert_style,
+                                                            is_open=False,
+                                                            children=[
+                                                                dcc.Markdown(
+                                                                    # Message for analysis
+                                                                    id="analysis-postview-message"
+                                                                ),
+                                                            ],
+                                                        ),
+                                                    ]
                                                 ),
                                             ]
                                         ),

--- a/app/pages/preview.py
+++ b/app/pages/preview.py
@@ -43,6 +43,9 @@ layout = preview_layout
     Output("post-analysis-first-well-img-view-alert", "is_open"),
     Output("no-store-data-alert", "is_open"),
     Output("submit-val", "disabled"),
+    Output("analysis-preview-message-alert", "is_open"),
+    Output("analysis-preview-dx-alert-message", "is_open"),
+    Output("analysis-preview-dx-message", "children"),
     State("preview-dropdown", "value"),
     Input("preview-change-img-button", "n_clicks"),
     State("store", "data"),
@@ -73,19 +76,25 @@ def update_analysis_preview_imgage(selection, nclicks, store):
     """
     # Check if store is empty
     if not store:
-        return None, True, False, True, True
+        return (
+            None,
+            True,
+            False,
+            True,
+            True,
+            True,
+            False,
+            None,
+        )
 
-    # Get the store data
     volume = store["mount"]
     platename = store["platename"]
     wells = store["wells"]
     plate_base = platename.split("_", 1)[0]
     pipeline_selection = store["pipeline_selection"]
 
-    if nclicks:  # If the button has been clicked
-
+    if nclicks:
         if pipeline_selection == "motility":
-            # assumes IX-like file structure
             if selection == "raw":
                 selection = ""
             elif selection == "segment":
@@ -96,23 +105,7 @@ def update_analysis_preview_imgage(selection, nclicks, store):
             img_path = Path(
                 f"{volume}/work/{platename}/{wells[0]}/img/{platename}_{wells[0]}{selection}.png"
             )
-
-            # Check if the image exists
-            if os.path.exists(img_path):
-
-                # checking the selection and changing the scale accordingly
-                if selection == "_motility":
-                    scale = "inferno"
-                else:
-                    scale = "gray"
-
-                # Open the image and create a figure
-                fig = create_figure_from_filepath(img_path, scale=scale)
-
-                # Return the figure and the open status of the alerts
-                return fig, False, True, False, ""
         elif pipeline_selection == "fecundity":
-            # assumes IX-like file structure
             if selection == "raw":
                 selection = ""
             else:
@@ -121,17 +114,7 @@ def update_analysis_preview_imgage(selection, nclicks, store):
             img_path = Path(
                 f"{volume}/work/{platename}/{wells[0]}/img/{platename}_{wells[0]}{selection}.png"
             )
-
-            # Check if the image exists
-            if os.path.exists(img_path):
-
-                # Open the image and create a figure
-                fig = create_figure_from_filepath(img_path)
-
-                # Return the figure and the open status of the alerts
-                return fig, False, True, False, ""
         elif pipeline_selection == "tracking":
-            # assumes IX-like file structure
             if selection == "raw":
                 selection = ""
             else:
@@ -140,113 +123,66 @@ def update_analysis_preview_imgage(selection, nclicks, store):
             img_path = Path(
                 f"{volume}/work/{platename}/{wells[0]}/img/{platename}_{wells[0]}{selection}.png"
             )
-
-            # Check if the image exists
-            if os.path.exists(img_path):
-
-                # Open the image and create a figure
-                fig = create_figure_from_filepath(img_path)
-
-                # Return the figure and the open status of the alerts
-                return fig, False, True, False, ""
         elif pipeline_selection == "wormsize_intensity_cellpose":
-
-            # assumes IX-like file structure
             if selection == "raw":
-
                 img_path = Path(
                     f"{volume}/work/{platename}/{wells[0]}/img/{platename}_{wells[0]}.png"
                 )
-
             elif selection == "straightened_worms":
-
                 img_path = Path(
                     f"{volume}/output/straightened_worms/{plate_base}_{wells[0]}.tiff"
                 )
-
             elif selection == "cp_masks":
                 img_path = Path(
                     f"{volume}/input/{platename}/TimePoint_1/{plate_base}_{wells[0]}_cp_masks.png"
                 )
-
-            # Check if the image exists
-            if os.path.exists(img_path):
-
-                # Open the image and create a figure
-                fig = create_figure_from_filepath(img_path)
-
-                # Return the figure and the open status of the alerts
-                return fig, False, True, False, ""
         elif pipeline_selection == "mf_celltox":
-            # assumes IX-like file structure
             if selection == "raw":
-
                 img_path = Path(
                     f"{volume}/work/{platename}/{wells[0]}/img/{platename}_{wells[0]}.png"
                 )
-
-            # Check if the image exists
-            if os.path.exists(img_path):
-
-                # Open the image and create a figure
-                fig = create_figure_from_filepath(img_path)
-
-                # Return the figure and the open status of the alerts
-                return fig, False, True, False, ""
         elif pipeline_selection == "wormsize":
-            # assumes IX-like file structure
             if selection == "raw":
-
                 img_path = Path(
                     f"{volume}/work/{platename}/{wells[0]}/img/{platename}_{wells[0]}.png"
                 )
-
             elif selection == "straightened_worms":
-
                 img_path = Path(
                     f"{volume}/output/straightened_worms/{plate_base}_{wells[0]}.tiff"
                 )
-
-            # Check if the image exists
-            if os.path.exists(img_path):
-
-                # Open the image and create a figure
-                fig = create_figure_from_filepath(img_path)
-
-                # Return the figure and the open status of the alerts
-                return fig, False, True, False, ""
         elif pipeline_selection == "feeding":
-            # assumes IX-like file structure
             if selection == "raw":
-
                 img_path = Path(
                     f"{volume}/work/{platename}/{wells[0]}/img/{platename}_{wells[0]}.png"
                 )
-
             elif selection == "straightened_worms":
-
                 img_path = Path(
                     f"{volume}/output/straightened_worms/{plate_base}_{wells[0]}.tiff"
                 )
-
             elif selection.startswith("wavelength_"):
-
                 selection = selection.split("_", 1)[-1]
                 img_path = Path(
                     f"{volume}/work/{platename}/{wells[0]}/img/{platename}_{wells[0]}_{selection}.png"
                 )
-
-            # Check if the image exists
-            if os.path.exists(img_path):
-
-                # Open the image and create a figure
-                fig = create_figure_from_filepath(img_path)
-
-                # Return the figure and the open status of the alerts
-                return fig, False, True, False, ""
         else:
-            return None, True, False, False, False
-    return None, True, False, False, False
+            return None, True, False, False, False, True, False, None
+
+        print(f"Generated image path: {img_path}")  # Debugging output
+
+        if os.path.exists(img_path):
+            scale = "inferno" if selection == "_motility" else "gray"
+            fig = create_figure_from_filepath(img_path, scale=scale)
+            return (
+                fig,
+                False,
+                True,
+                False,
+                "",
+                False,
+                True,
+                f"```{img_path}```",
+            )
+    return None, True, False, False, False, True, False, None
 
 
 @callback(

--- a/app/utils/background_callback.py
+++ b/app/utils/background_callback.py
@@ -57,6 +57,7 @@ def callback(set_progress, n_clicks, store):
                 True,
                 "No configuration found. Please go to the configuration page to set up the analysis.",
                 "No configuration found. Please go to the configuration page to set up the analysis.",
+                None,
             )
 
         # obtain the necessary data from the store
@@ -103,6 +104,7 @@ def callback(set_progress, n_clicks, store):
             True,
             "An error has occurred. Please see the log file for more information.",
             f"```{error_message}```",
+            None,
         )
 
 
@@ -310,6 +312,7 @@ def tracking_wrmXpress_run(store, set_progress):
             True,
             "An error has occurred. Please see the log file for more information.",
             f"```{error_message}```",
+            None,
         )
 
 
@@ -356,6 +359,7 @@ def motility_or_segment_run(store, set_progress):
             True,
             "An error has occurred. Please see the log file for more information.",
             f"```{error_message}```",
+            None,
         )
 
 
@@ -457,6 +461,7 @@ def fecundity_run(store, set_progress):
             True,
             "An error has occurred. Please see the log file for more information.",
             f"```{error_message}```",
+            None,
         )
 
 
@@ -559,6 +564,7 @@ def cellprofile_wormsize_run(store, set_progress):
             True,
             "An error has occurred. Please see the log file for more information.",
             f"```{error_message}```",
+            None,
         )
 
 
@@ -678,6 +684,7 @@ def cellprofile_wormsize_intesity_cellpose_run(store, set_progress):
             True,
             "An error has occurred. Please see the log file for more information.",
             f"```{error_message}```",
+            None,
         )
 
 
@@ -787,6 +794,7 @@ def cellprofile_mf_celltox_run(store, set_progress):
             True,
             "An error has occurred. Please see the log file for more information.",
             f"```{error_message}```",
+            None,
         )
 
 
@@ -895,6 +903,7 @@ def cellprofile_feeding_run(store, set_progress):
             True,
             "An error has occurred. Please see the log file for more information.",
             f"```{error_message}```",
+            None,
         )
 
 
@@ -1424,7 +1433,14 @@ def handle_thumbnail_generation(volume, platename, docker_output, output_file):
         fig_1 = create_figure_from_filepath(output_path)
         docker_output.append("Thumbnail generation completed successfully.")
         docker_output_formatted = "".join(docker_output)
-        return fig_1, False, False, "", f"```{docker_output_formatted}```"
+        return (
+            fig_1,
+            False,
+            False,
+            "",
+            f"```{docker_output_formatted}```",
+            f"```{output_path}```",
+        )
     else:
 
         error_message = f"Thumbnail generation failed, please check the {output_file}."
@@ -1435,13 +1451,12 @@ def handle_thumbnail_generation(volume, platename, docker_output, output_file):
             True,
             f"{error_message}",
             f"```{docker_output_formatted}```",
+            None,
         )
 
 
 def handle_failure(docker_output, output_file):
-    error_message = (
-        f"wrmXpress has failed, please check the {output_file} for more information. Then clear the `work` directory and try again."
-    )
+    error_message = f"wrmXpress has failed, please check the {output_file} for more information. Then clear the `work` directory and try again."
     docker_output_formatted = "".join(docker_output)
     return (
         None,
@@ -1449,6 +1464,7 @@ def handle_failure(docker_output, output_file):
         True,
         f"{error_message}",
         f"```{docker_output_formatted}```",
+        None,
     )
 
 

--- a/app/utils/styling.py
+++ b/app/utils/styling.py
@@ -48,3 +48,10 @@ layout = go.Layout(
     ),
     # width=800,
 )
+
+# Clear alert style
+clear_alert_style = {
+    "backgroundColor": "transparent",
+    "border": "none",
+    "color": "#000",  # Optional: Set the text color
+}


### PR DESCRIPTION
run_layout.py:
- added clear alerts to markdowns for file paths while analysis is running / once finished and to when switching dx image. This was necessay b/c dash does not allow the same ID to be an Output for multiple @callbacks. When selecting an dx image following the analysis the dbc.Alert(id="run-page-file-paths-alert") closes and the dbc.Alert(id="run-page-file-paths-alert-update") opens -- see run.py load_analysis_img function for usage.

preview_layout.py:
- added clear alerts  to markdowns for file paths while analysis is running / once finished and to when switching dx image. See run_layout.py explination as same logic was used. Subsequently updated preview.py for usage of these alerts, see update_analysis_preview_imgage function for usage.

app.py:
 - added output for markdown of filepath of image appearing on screen once analysis is finshed.

backgroud_callbacks.py:
 - added the filepath output to all necessary functions.

 styling.py:
  - added the clear alert parameters for filepath alerts